### PR TITLE
Fix broken imports after restructuring

### DIFF
--- a/grpc_server.py
+++ b/grpc_server.py
@@ -3,7 +3,8 @@ from concurrent import futures
 import json
 import instrument_pb2
 import instrument_pb2_grpc
-import services.instrument as instr_module
+# Updated import path after project restructure
+import instrument as instr_module
 
 class InstrumentServiceServicer(instrument_pb2_grpc.InstrumentServiceServicer):
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
-from api.routes import router as api_router
+# Updated import path after project restructure
+from routes import router as api_router
 from contextlib import asynccontextmanager
 import uvicorn
 import os
@@ -26,20 +27,20 @@ if not os.path.exists("static"):
     os.makedirs("static")
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
-# Include all the API endpoints from api/routes.py
+# Include all the API endpoints from routes.py
 app.include_router(api_router, prefix="/api")
 
 @app.get("/", response_class=HTMLResponse)
 async def root():
     """Serves the main index.html file."""
     try:
-        with open("static/index.html", "r") as file:
+        with open("index.html", "r") as file:
             return file.read()
     except FileNotFoundError:
         # Provide a helpful message if the UI file is missing
         return """
-        <h1>Error: static/index.html not found</h1>
-        <p>Please ensure the index.html file is in a 'static' sub-directory.</p>
+        <h1>Error: index.html not found</h1>
+        <p>Please ensure the index.html file is present in the project root.</p>
         """
 
 if __name__ == "__main__":

--- a/readme.md
+++ b/readme.md
@@ -18,17 +18,13 @@ A modern FastAPI web application for remote control and monitoring of the Keithl
 
 ```
 main.py
-api/
-    routes.py
-models/
-    schema.py
-services/
-    instrument.py
-    monitor.py
-static/
-    index.html
-utils/
-    helpers.py
+routes.py
+schema.py
+instrument.py
+monitor.py
+grpc_server.py / grpc_client.py
+helpers.py
+index.html
 ```
 
 ---


### PR DESCRIPTION
## Summary
- fix gRPC server import path
- update FastAPI app import path and HTML loader
- adjust project structure section in README

## Testing
- `python -m py_compile grpc_server.py main.py routes.py instrument.py grpc_client.py monitor.py helpers.py schema.py`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687841cba4b88331ae0e1205fb6178ea