### PR TITLE
Fix API import path

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 # Updated import path after project restructure
-from routes import router as api_router
+from api.routes import router as api_router
 from contextlib import asynccontextmanager
 import uvicorn
 import os


### PR DESCRIPTION
## Summary
- adjust FastAPI router import to use `api.routes`

## Testing
- `python -m py_compile main.py api/routes.py services/instrument.py services/monitor.py models/schema.py grpc_client.py grpc_server.py utils/helpers.py`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68784ab017d88331830868ea333535f0