### PR TITLE
Fix import path for gRPC server

### DIFF
--- a/grpc_server.py
+++ b/grpc_server.py
@@ -4,7 +4,7 @@ import json
 import instrument_pb2
 import instrument_pb2_grpc
 # Updated import path after project restructure
-import instrument as instr_module
+from services import instrument as instr_module
 
 class InstrumentServiceServicer(instrument_pb2_grpc.InstrumentServiceServicer):
 


### PR DESCRIPTION
## Summary
- fix path to instrument module inside gRPC server

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python grpc_server.py` *(fails: ModuleNotFoundError: No module named 'grpc')*

------
https://chatgpt.com/codex/tasks/task_e_68784f0c456c8331907306922eb1aafe